### PR TITLE
Adding UTF-8 encoding to `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ from setuptools import (
 
 from urs.Version import __version__
 
-with open("README.md", "r") as readme:
+with open("README.md", "r", encoding = "utf-8") as readme:
     LONG_DESCRIPTION = readme.read()
 
 NAME = "urs"


### PR DESCRIPTION
# Overview

## Summary

Adding UTF-8 encoding to `setup.py` - an error is raised when opening the `README` without specifying the encoding parameter.

## Motivation/Context

@1011025m mentioned this issue when installing URS on his Windows 10 machine.

## New Dependencies

```
None
```

## Issue Fix or Enhancement Request

Fixes #38

# Type of Change

* [x] Bug Fix (non-breaking change which fixes an issue)

# Breaking Change

N/A

# List All Changes That Have Been Made

### Added

* Source code
    + Modified `setup.py`:
        * Added `encoding = "utf-8"` to the `open()` method's parameters.

# How Has This Been Tested?

* Tested installation process on local machine after adding the encoding parameter.

## Test Configuration

* Python version: 3.9.5

## Dependencies

```
N/A
```

# Checklist

* [x] My code follows the [style guidelines][Style Guide] of this project.
* [x] I have performed a self-review of my own code, including testing to ensure my fix is effective or that my feature works.
* [x] My changes generate no new warnings.
* [x] I have commented my code, providing a summary of the functionality of each method, particularly in areas that may be hard to understand.
* [x] I have made corresponding changes to the documentation.
* [x] I have performed a self-review of this Pull Request template, ensuring the Markdown file renders correctly.

<!-- LINKS -->
[Style Guide]: STYLE_GUIDE.md
