### PR TITLE
Update | GitHub Actions Workflow Triggers

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches-ignore:
       - "demo-gifs"
+      - "gh-pages"
       - "rust-demo"
       - "samples"
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,6 +1,9 @@
 name: Python code checks
 
 on:
+  push:
+    branches:
+      - "master"
   pull_request:
     branches-ignore:
       - "demo-gifs"
@@ -29,6 +32,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macOS-latest]
 
+    if: github.ref == "refs/heads/master"
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macOS-latest]
 
-    if: github.ref == "refs/heads/master"
+    if: github.ref == 'refs/heads/master'
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches-ignore:
       - "demo-gifs"
+      - "gh-pages"
       - "rust-demo"
       - "samples"
 


### PR DESCRIPTION
# Summary

The [`pytest` GitHub Actions Workflow job](https://github.com/JosephLai241/URS/actions/runs/5054138036/jobs/9116036214) is unable to properly execute because it appears unable to find the environment secrets set in this repository. I believe this is due to the pull request opener ([Dependabot](https://github.com/dependabot) in this case) not having the correct permissions to this repository.

I have added a conditional to the Workflow file to only trigger when pushing to the `master` branch. I have also added the `gh-pages` branch to the `branches-ignore` filter.

# Motivation/Context

It sure would be nice if the Actions worked as intended.

# Issue Fix or Enhancement Request

- (Hopefully) fixes an issue where the `pytest` GitHub Actions Workflow job is unable to find the repository's secrets.

# Type of Change

- [x] Bug Fix (non-breaking change which fixes an issue)

# List the Most Significant Changes That Have Been Made

## Changed

- Updated the `python.yml` GitHub Actions Workflow file by adding a conditional to only trigger the `pytest` job when pushing to the `master` branch.

# Checklist

- [x] My code follows the [style guidelines][style guide] of this project.
- [x] I have performed a self-review of my own code, including testing to ensure my fix is effective or that my feature works.
- [x] My changes generate no new warnings.
- [x] I have commented my code, providing a summary of the functionality of each method, particularly in areas that may be hard to understand.
- [x] I have made corresponding changes to the documentation.
- [x] I have performed a self-review of this Pull Request template, ensuring the Markdown file renders correctly.

<!-- LINKS -->

[style guide]: STYLE_GUIDE.md
